### PR TITLE
Fix tiny const correctness issue

### DIFF
--- a/zmessage.inc
+++ b/zmessage.inc
@@ -53,7 +53,7 @@ static const
 	Functions
 */
 
-stock ZMsg_GetMessages(message[], array[][], const lines = sizeof(array), const line_size = sizeof(array[]))
+stock ZMsg_GetMessages(const message[], array[][], const lines = sizeof(array), const line_size = sizeof(array[]))
 {
 	new length = strlen(message);
 


### PR DESCRIPTION
3.10.9 of the community compiler produces const-correctness warnings now. This fixes that!